### PR TITLE
Add a prerequisite to install netlify-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ This is a small CLI to allow you to migrate all your sites to the Focal build im
 
 This CLI makes multiple requests to the Netlify API, so it can take a few seconds to complete. Please be patient!
 
+### Prerequisite:
+
+Get [netlify-cli](https://docs.netlify.com/cli/get-started/) installed in your machine before listing or updating sites :
+
+```bash
+npm install netlify-cli -g
+```
+or
+```bash
+yarn global add netlify-cli
+```
+
 ### First, check which sites are not running the Focal image on your account:
 
 ```bash


### PR DESCRIPTION
First of all, thanks a lot for this amazing tool!

I would like to add a prerequisite as one might confuse if not having `netlify-cli` installed  :

```bash
❯ npx ntl-focal-migrate --list --account "<your team name>"

 ntl-focal-migrate  v0.0.1 by Jason Lengstorf
Find all your sites that don’t use the new Focal build image and migrate them.


✖ UNHANDLED ERROR
✖ ERROR → Error
ℹ REASON → Command failed with ENOENT: netlify sites:list --json
spawn netlify ENOENT
ℹ ERROR STACK ↓ 
 Error: Command failed with ENOENT: netlify sites:list --json
spawn netlify ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:274:19)
    at onErrorNT (internal/child_process.js:469:16)
    at processTicksAndRejections (internal/process/task_queues.js:82:21)
```

Thanks a lot and have a good day!